### PR TITLE
Update payer dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/Components/Dashboards.tsx
+++ b/src/Components/Dashboards.tsx
@@ -97,7 +97,7 @@ const Dashboard: React.FC<{ user: User | null }> = ({ user }) => {
       icon: (
         <Support className="text-[22px] sm:text-[26px] md:text-[28px] w-[22px] sm:w-[26px] md:w-[28px] mr-[10px]" />
       ),
-      allowedUserTypes: ["customer-support", "payer "],
+      allowedUserTypes: ["customer-support"],
     },
     {
       to: "/banks",

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -375,40 +375,39 @@ const Header = () => {
 
   const handleReassignBank = async () => {
     if (!selectedBank || !currentShift?.shift?.id) return;
-  
+
     try {
       toast.loading("Updating bank...");
       const res = await spendBank(selectedBank.id, {
         amountUsed: 0,
         shiftId: currentShift.shift.id,
       });
-      
+
       toast.dismiss();
-      
-      if (res?.success) { // Now checking the correct response structure
+
+      if (res?.success) {
         const updatedBank = res.data;
         toast.success("Bank reassigned successfully");
-  
-        // update to the *new* bank immediately
+
         setSelectedBank({
-          id:            updatedBank.id,
-          bankName:      updatedBank.bankName,
+          id: updatedBank.id,
+          bankName: updatedBank.bankName,
           accountNumber: updatedBank.accountNumber,
-          funds:         updatedBank.funds,
+          funds: updatedBank.funds,
         });
         setBankAmount(updatedBank.funds);
-  
+
         // re‑sync the rest of the shift
         await fetchCurrentShift();
         setShowBankModal(false);
-      } 
+      }
     } catch (error) {
       toast.dismiss();
       console.error("Error reassigning bank:", error);
       toast.error("Bank reassignment failed");
     }
   };
-  
+
 
   return (
     <header className="w-full border-b bg-white shadow-sm">
@@ -428,13 +427,13 @@ const Header = () => {
               </div>
             )}
             {user?.userType === "payer" && isClockedIn && bankAmount === 0 && (
-  <button
-    onClick={openBankSelection}
-    className="px-4 py-2 rounded-md bg-yellow-100 text-yellow-700 hover:bg-yellow-200 transition-colors"
-  >
-    Request New Bank
-  </button>
-)}
+              <button
+                onClick={openBankSelection}
+                className="px-4 py-2 rounded-md bg-yellow-100 text-yellow-700 hover:bg-yellow-200 transition-colors"
+              >
+                Request New Bank
+              </button>
+            )}
 
 
 
@@ -450,8 +449,8 @@ const Header = () => {
             <button
               onClick={handleClockInOut}
               className={`px-4 py-2 rounded-md font-medium transition-colors ${isClockedIn
-                  ? "bg-red-100 text-red-600 hover:bg-red-200"
-                  : "bg-green-100 text-green-600 hover:bg-green-200"
+                ? "bg-red-100 text-red-600 hover:bg-red-200"
+                : "bg-green-100 text-green-600 hover:bg-green-200"
                 }`}
             >
               <div className="flex items-center gap-2">
@@ -468,8 +467,8 @@ const Header = () => {
               onClick={handleBreak}
               disabled={!isClockedIn}
               className={`px-4 py-2 rounded-md font-medium transition-colors ${isOnBreak
-                  ? "bg-yellow-100 text-yellow-600 hover:bg-yellow-200"
-                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                ? "bg-yellow-100 text-yellow-600 hover:bg-yellow-200"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
                 } ${!isClockedIn && "opacity-50 cursor-not-allowed"}`}
             >
               <div className="flex items-center gap-2">
@@ -535,47 +534,48 @@ const Header = () => {
 
         {/* Bank selection modal */}
         {showBankModal && (
-  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-    <div className="bg-white p-6 rounded-lg w-96">
-      <h2 className="text-xl font-semibold mb-4">Select Bank for Today</h2>
-      <ul className="max-h-64 overflow-y-auto mb-4">
-        {banks.map((bank) => (
-          <li key={bank.id} className="mb-2">
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="bank"
-                checked={selectedBank?.id === bank.id}
-                onChange={() => {
-                  setSelectedBank(bank);
-                  setBankAmount(bank.funds);
-                }}
-              />
-              <span className="ml-2">
-                {bank.bankName} - {bank.accountNumber} (₦{bank.funds.toLocaleString()})
-              </span>
-            </label>
-          </li>
-        ))}
-      </ul>
-      <div className="flex justify-end gap-2">
-        <button 
-          onClick={() => setShowBankModal(false)} 
-          className="px-4 py-2 rounded bg-gray-200"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={isClockedIn ? handleReassignBank : confirmBankAndClockIn}
-          disabled={!selectedBank}
-          className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
-        >
-          {isClockedIn ? "Update Bank" : "Confirm & Clock In"}
-        </button>
-      </div>
-    </div>
-  </div>
-)}
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded-lg w-96">
+              <h2 className="text-xl font-semibold mb-4">Select Bank for Today</h2>
+              <ul className="max-h-64 overflow-y-auto mb-4">
+                {banks.map((bank) => (
+                  <li key={bank.id} className="mb-2">
+                    <label className="flex items-center">
+                      <input
+                        type="radio"
+                        name="bank"
+                        checked={selectedBank?.id === bank.id}
+                        onChange={() => {
+                          setSelectedBank(bank);
+                          setBankAmount(bank.funds);
+                        }}
+                      />
+                      <span className="ml-2">
+                        {bank.bankName} - {bank.accountNumber} (₦{bank.funds.toLocaleString()})
+                      </span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+              <h3 className="py-2 rounded text-red-500"><span className="px-4 py-2 rounded text-black">Note: </span> If the amount displayed is not equal to the amount you have at hand, please notify your Rater to update amount for this bank </h3>
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setShowBankModal(false)}
+                  className="py-2 rounded bg-gray-200"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={isClockedIn ? handleReassignBank : confirmBankAndClockIn}
+                  disabled={!selectedBank}
+                  className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
+                >
+                  {isClockedIn ? "Update Bank" : "Confirm & Clock In"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Closing balances modal */}
         {showCloseModal && (
@@ -602,6 +602,7 @@ const Header = () => {
                       </label>
                     </li>
                   ))}
+                  <h3 className="py-2 rounded text-red-500"><span className="px-4 py-2 rounded text-black">Note: </span> If the amount displayed is not equal to the amount you have at hand, please notify your Rater to update amount for this bank </h3>
                 </ul>
               ) : (
                 <p className="text-gray-500 mb-4">No banks found for this shift.</p>

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -466,15 +466,23 @@ const Header = () => {
             {error && <div className="text-red-500">{error}</div>}
 
             {selectedBank && isClockedIn && (
-              <div className="flex items-center gap-2">
-                <span className="font-medium">
-                  Bank: {selectedBank.bankName} - {selectedBank.accountName}
-                </span>
-                <span className="px-2 py-1 bg-blue-100 text-blue-700 rounded-md font-semibold">
-                  &#8358;{Number(bankAmount).toLocaleString()}
-                </span>
-              </div>
-            )}
+  <div className="flex items-center gap-2">
+    <span className="font-medium">
+      Bank: {selectedBank.bankName} - {selectedBank.accountName}
+    </span>
+    {bankAmount > 0 && (
+      <span className={`px-2 py-1 rounded-md font-semibold ${
+        bankAmount >= 5000000 
+          ? 'bg-green-700 text-white' 
+          : bankAmount >= 1000000 
+            ? 'bg-orange-500 text-white' 
+            : 'bg-red-600 text-white'
+      }`}>
+        ₦{Number(bankAmount).toLocaleString()}
+      </span>
+    )}
+  </div>
+)}
             {user?.userType === "payer" && isClockedIn && bankAmount === 0 && (
               <button
                 onClick={openBankSelection}

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -584,7 +584,7 @@ const Header = () => {
         {/* Bank selection modal */}
         {showBankModal && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="bg-white p-6 rounded-lg w-96">
+            <div className="bg-white p-16 rounded-lg">
               <h2 className="text-xl font-semibold mb-4">Select Bank for Today</h2>
               <ul className="max-h-64 overflow-y-auto mb-4">
                 {banks.map((bank) => (
@@ -635,7 +635,7 @@ const Header = () => {
         {/* Closing balances modal */}
         {showCloseModal && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="bg-white p-6 rounded-lg w-96">
+            <div className="bg-white p-6 rounded-lg">
               <h2 className="text-xl font-semibold mb-4">Confirm Closing Balances</h2>
               {shiftBanks.length > 0 ? (
                 <ul className="max-h-64 overflow-y-auto mb-4">
@@ -674,7 +674,7 @@ const Header = () => {
                 </button>
                 <button
                   onClick={confirmCloseAndClockOut}
-                  className="px-4 py-2 rounded bg-red-600 text-white disabled:opacity-50"
+                  className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-50"
                 >
                   Confirm & Clock Out
                 </button>

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -642,7 +642,7 @@ const Header = () => {
                   {shiftBanks.map((bank) => (
                     <li key={bank.id} className="mb-2">
                       <label className="flex flex-col">
-                        <span className="font-medium">{bank.bankName}</span>
+                        <span className="font-medium">{bank.bankName} - {bank.accountName}</span>
                         <input
                           type="number"
                           className="border rounded p-2 mt-1"

--- a/src/Pages/Bank/Banks.tsx
+++ b/src/Pages/Bank/Banks.tsx
@@ -33,6 +33,7 @@ import {
   getFundedBanks,
   getRolloverBanks,
   useBank as spendBank,
+  getUsedBanks
 } from "../../api/bank";
 import { getCurrentShift } from "../../api/shift";
 import Loading from "../../Components/Loading";
@@ -87,11 +88,13 @@ const Banks = () => {
   const tabOptions: { label: string; value: TabOption }[] =
     user?.userType === "payer"
       ? [
-          { label: "Funded Banks", value: "funded" }
+          { label: "Funded Banks", value: "funded" },
+          { label: "Used", value: "used" }
         ]
       : [
           { label: "All Banks", value: "all" },
           { label: "Funded Banks", value: "funded" },
+          { label: "Used", value: "used" },
           { label: "Unfunded", value: "free" },
           { label: "Rollover Banks", value: "rollover" },
         ];
@@ -137,6 +140,9 @@ const Banks = () => {
           break;
         case "free":
           res = await getFreeBanks();
+          break;
+        case "used":
+          res = await getUsedBanks();
           break;
         case "rollover":
           res = await getRolloverBanks();

--- a/src/Pages/Bank/Banks.tsx
+++ b/src/Pages/Bank/Banks.tsx
@@ -38,7 +38,7 @@ import { getCurrentShift } from "../../api/shift";
 import Loading from "../../Components/Loading";
 import { useNavigate } from "react-router-dom";
 import { useUserContext } from "../../Components/ContextProvider";
-import ClockedAlt from "../../Components/ClockedAlt";
+// import ClockedAlt from "../../Components/ClockedAlt";
 
 enum BankTag {
   FRESH = "fresh",
@@ -174,8 +174,8 @@ const Banks = () => {
   };
 
   if (loading) return <Loading />;
-  if (!user?.clockedIn && user?.userType !== "admin")
-    return <ClockedAlt />;
+  // if (!user?.clockedIn && user?.userType !== "admin")
+  //   return <ClockedAlt />;
 
   return (
     <div className="space-y-6 min-h-screen font-primary">

--- a/src/Pages/CC/CustomerCare.tsx
+++ b/src/Pages/CC/CustomerCare.tsx
@@ -90,7 +90,7 @@ export interface Trade {
   isLive?: boolean;
 }
 
-const REFRESH_INTERVAL = 300000;
+const REFRESH_INTERVAL = 30000;
 
 const ExportButtons = ({
   data,
@@ -346,21 +346,25 @@ const CustomerSupport: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    isMounted.current = true;
-    fetchData(true);
-    
-    refreshInterval.current = setInterval(() => {
-      debouncedRefresh();
-    }, REFRESH_INTERVAL);
-
+    // on mount or tabValue change, clear any existing timer
+    if (refreshInterval.current) {
+      clearInterval(refreshInterval.current);
+    }
+  
+    // only start the auto‑refresh loop if we're *not* on tab 0 (Escalated)
+    if (tabValue !== 0) {
+      refreshInterval.current = setInterval(() => {
+        debouncedRefresh();
+      }, REFRESH_INTERVAL);
+    }
+  
+    // cleanup on unmount
     return () => {
-      isMounted.current = false;
       if (refreshInterval.current) {
         clearInterval(refreshInterval.current);
       }
-      debouncedRefresh.cancel();
     };
-  }, [fetchData, debouncedRefresh]);
+  }, [tabValue, debouncedRefresh]);
 
   const refreshData = async () => {
     await fetchData(true);

--- a/src/Pages/CC/CustomerCare.tsx
+++ b/src/Pages/CC/CustomerCare.tsx
@@ -346,6 +346,18 @@ const CustomerSupport: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    isMounted.current = true;
+    fetchData(true);
+    
+    return () => {
+      isMounted.current = false;
+      if (refreshInterval.current) {
+        clearInterval(refreshInterval.current);
+      }
+    };
+  }, [fetchData]);
+
+  useEffect(() => {
     // on mount or tabValue change, clear any existing timer
     if (refreshInterval.current) {
       clearInterval(refreshInterval.current);

--- a/src/Pages/CC/EscalatedDetails.tsx
+++ b/src/Pages/CC/EscalatedDetails.tsx
@@ -154,43 +154,42 @@ const EscalatedDetails: React.FC = () => {
     fetchTradeDetails();
   }, [tradeId]);
 
+  // const handleCancelTrade = async () => {
+  //   setCancelTradeState(true);
+  //   try {
+  //     if (!tradeId) {
+  //       toast.error("Trade ID is missing", errorStyles);
+  //       return;
+  //     }
 
-  const handleCancelTrade = async () => {
-    setCancelTradeState(true);
-    try {
-      if (!tradeId) {
-        toast.error("Trade ID is missing", errorStyles);
-        return;
-      }
+  //     const res = await cancelTradeRequest(tradeId);
+  //     console.log("Cancel trade response:", res);
 
-      const res = await cancelTradeRequest(tradeId);
-      console.log("Cancel trade response:", res);
+  //     if (res) {
+  //       toast.success("Trade cancelled successfully", successStyles);
 
-      if (res) {
-        toast.success("Trade cancelled successfully", successStyles);
+  //       // Update local state to reflect the cancelled status
+  //       setEscalatedTrade((prev: any) => ({
+  //         ...prev,
+  //         status: 'cancelled'
+  //       }));
 
-        // Update local state to reflect the cancelled status
-        setEscalatedTrade((prev: any) => ({
-          ...prev,
-          status: 'cancelled'
-        }));
-
-        // Navigate back to the list after a short delay
-        setTimeout(() => {
-          navigate("/customer-support");
-        }, 2000);
-      } else {
-        setTimeout(() => {
-          navigate("/customer-support");
-        }, 2000);
-      }
-    } catch (error) {
-      console.error("Error cancelling trade:", error);
-      toast.error("An error occurred while cancelling the trade", errorStyles);
-    } finally {
-      setCancelTradeState(false);
-    }
-  };
+  //       // Navigate back to the list after a short delay
+  //       setTimeout(() => {
+  //         navigate("/customer-support");
+  //       }, 2000);
+  //     } else {
+  //       setTimeout(() => {
+  //         navigate("/customer-support");
+  //       }, 2000);
+  //     }
+  //   } catch (error) {
+  //     console.error("Error cancelling trade:", error);
+  //     toast.error("An error occurred while cancelling the trade", errorStyles);
+  //   } finally {
+  //     setCancelTradeState(false);
+  //   }
+  // };
 
 
   const formatWATDateTime = (date: Date | string) => {
@@ -511,7 +510,7 @@ const EscalatedDetails: React.FC = () => {
 
 
 
-            <Button
+            {/* <Button
               variant="contained"
               fullWidth
               sx={{ mt: 2 }}
@@ -519,7 +518,7 @@ const EscalatedDetails: React.FC = () => {
               disabled={cancelTradeState}
             >
               {cancelTradeState ? "Cancelling..." : "Cancel Trade"}
-            </Button>
+            </Button> */}
 
           </Paper>
 
@@ -823,7 +822,9 @@ const EscalatedDetails: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-      <Dialog
+
+
+      {/* <Dialog
         open={confirmCancelOpen}
         onClose={() => setConfirmCancelOpen(false)}
       >
@@ -848,7 +849,9 @@ const EscalatedDetails: React.FC = () => {
             Yes
           </Button>
         </DialogActions>
-      </Dialog>
+      </Dialog> */}
+
+
     </Box>
   );
 };

--- a/src/Pages/CC/EscalatedDetails.tsx
+++ b/src/Pages/CC/EscalatedDetails.tsx
@@ -90,6 +90,7 @@ const EscalatedDetails: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const theme = useTheme();
+  const [reassigning, setReassigning] = useState(false);
 
   const scrollToBottom = () => {
     messagesEndRef?.current?.scrollIntoView({ behavior: "smooth" });
@@ -224,17 +225,15 @@ const EscalatedDetails: React.FC = () => {
       toast.error("Missing required data", errorStyles);
       return;
     }
-
+  
+    setReassigning(true); // start loading
+  
     try {
-      console.log("Reassigning trade:", {
-        tradeId: escalatedTrade.id,
-      });
-
       const response = await reAssignTrade(escalatedTrade.id);
-
+  
       if (response?.success) {
         toast.success("Trade reassigned successfully", successStyles);
-        fetchTradeDetails();
+        await fetchTradeDetails();
       } else {
         toast.error(response?.message || "Failed to reassign trade", errorStyles);
       }
@@ -244,9 +243,10 @@ const EscalatedDetails: React.FC = () => {
         error.response?.data?.message || "Failed to reassign trade",
         errorStyles
       );
+    } finally {
+      setReassigning(false); // end loading
     }
   };
-
 
   const handleSendMessage = async () => {
     // 1) guard on having a trade ID & nonempty text
@@ -425,13 +425,15 @@ const EscalatedDetails: React.FC = () => {
             </Typography>
 
             <Button
-              variant="contained"
-              fullWidth
-              sx={{ mt: 2 }}
-              onClick={handleReAssign}
-            >
-              Reassign Trade
-            </Button>
+  variant="contained"
+  fullWidth
+  sx={{ mt: 2 }}
+  onClick={handleReAssign}
+  disabled={reassigning}
+  startIcon={reassigning ? <CircularProgress size={20} color="inherit" /> : null}
+>
+  {reassigning ? "Reassigning..." : "Reassign Trade"}
+</Button>
 
 
             <Box sx={{ mb: 2, mt: 2 }}>

--- a/src/Pages/Dashboard/PayerDashboard.tsx
+++ b/src/Pages/Dashboard/PayerDashboard.tsx
@@ -136,6 +136,7 @@ const PayerDashboard = () => {
       if (isInitial) setInitialLoading(true);
 
       const tradeData = await getPayerTrade(user?.id);
+      console.log('Trade data from API:', tradeData);
 
       // No trade assigned
       if (!tradeData?.success) {

--- a/src/Pages/Inbox/Inbox.tsx
+++ b/src/Pages/Inbox/Inbox.tsx
@@ -85,8 +85,7 @@ const Inbox: React.FC = () => {
 
   // Initialize socket connection
   useEffect(() => {
-    // socketRef.current = io("https://r845fh.bibuain.ng"); 
-    socketRef.current = io("https://svmfu33phm.ap-southeast-1.awsapprunner.com");
+    socketRef.current = io(import.meta.env.VITE_SOCKET_BASE_URL);
 
     if (user?.id) {
       socketRef.current.emit("join", user.id);
@@ -358,7 +357,7 @@ const Inbox: React.FC = () => {
       return (
         <Box sx={{ mt: 1, mb: 1, maxWidth: "100%" }}>
           <img
-            src={`https://r845fh.bibuain.ng${attachment.url}`}
+            src={`${import.meta.env.VITE_SOCKET_BASE_URL}${attachment.url}`}
             alt={attachment.name}
             style={{
               maxWidth: "100%",
@@ -398,7 +397,7 @@ const Inbox: React.FC = () => {
         <IconButton
           size="small"
           component="a"
-          href={`https://r845fh.bibuain.ng${attachment.url}`}
+          href={`${import.meta.env.VITE_SOCKET_BASE_URL}${attachment.url}`}
           download
           sx={{ ml: 1 }}
         >

--- a/src/api/bank.ts
+++ b/src/api/bank.ts
@@ -18,6 +18,15 @@ export const addBank = async (data: unknown) => {
   }
 };
 
+export const getUsedBanks = async (): Promise<ResInterface> => {
+  try {
+    const res: ResInterface = await api.get("/banks/used");
+    return res;
+  } catch (error) {
+    handleApiError(error);
+  }
+};
+
 // Function to get all banks (Admin/Rater)
 export const getAllBanks = async () => {
   try {

--- a/src/api/shift.ts
+++ b/src/api/shift.ts
@@ -1,4 +1,3 @@
-// shiftApi.ts
 import { api, handleApiError } from "./user";
 import toast from "react-hot-toast";
 import { loadingStyles, successStyles } from "../lib/constants";

--- a/src/api/trade.ts
+++ b/src/api/trade.ts
@@ -18,6 +18,7 @@ interface CostPriceResponse {
 
 export interface ApiResponse<T = any> {
   success: boolean;
+  failure?: boolean;
   message: string;
   data?: T;
 }

--- a/src/api/trade.ts
+++ b/src/api/trade.ts
@@ -136,15 +136,6 @@ export const markTradeAsPaid = async (
   }
 };
 
-export const getDashboardStats = async () => {
-  try {
-    const res: ResInterface = await api.get("/trade/dashboard");
-    return res;
-  } catch (error) {
-    handleApiError(error);
-  }
-};
-
 export const getFeedbackStats = async (params: { username: string; platform: string }) => {
   try {
     const res: ResInterface = await api.get("/trade/feedback-stats", { params });
@@ -340,6 +331,24 @@ export const getEscalatedTrades = async () => {
   }
 };
 
+export const getDashboardStats = async () => {
+  try {
+    const res: ResInterface = await api.get("/trade/dashboard");
+    return res;
+  } catch (error) {
+    handleApiError(error);
+  }
+};
+
+export const getCCstats = async () => {
+  try {
+    const res: ResInterface = await api.get("/trade/ccstat");
+    return res;
+  } catch (error) {
+    handleApiError(error);
+  }
+};
+
 export const getEscalatedTradeById = async (id: string) => {
   try {
     const res: ResInterface = await api.get(`/trade/escalated-trades/${id}`);
@@ -374,15 +383,6 @@ export const activateDeactivatedOffers = async () => {
     return res;
   } catch (error) {
     console.error("Error in activateDeactivatedOffers:", error);
-    handleApiError(error);
-  }
-};
-
-export const getCCstats = async () => {
-  try {
-    const res: ResInterface = await api.get("/trade/ccstat");
-    return res;
-  } catch (error) {
     handleApiError(error);
   }
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,11 +1,11 @@
 // export const BASE_URL = "https://r845fh.bibuain.ng/api/v1";
 // export const SOCKET_BASE_URL = "https://r845fh.bibuain.ng";
 
-export const BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com/api/v1";
-export const SOCKET_BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com";
+// export const BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com/api/v1";
+// export const SOCKET_BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com";
 
-// export const BASE_URL = "http://localhost:7001/api/v1";
-// export const SOCKET_BASE_URL = "http://localhost:7001";
+export const BASE_URL = "http://localhost:7001/api/v1";
+export const SOCKET_BASE_URL = "http://localhost:7001";
 export const successStyles = {
   style: {
     maxWidth: "50rem",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,11 +1,6 @@
-// export const BASE_URL = "https://r845fh.bibuain.ng/api/v1";
-// export const SOCKET_BASE_URL = "https://r845fh.bibuain.ng";
 
-// export const BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com/api/v1";
-// export const SOCKET_BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com";
-
-export const BASE_URL = "http://localhost:7001/api/v1";
-export const SOCKET_BASE_URL = "http://localhost:7001";
+export const BASE_URL = import.meta.env.VITE_BASE_URL;
+export const SOCKET_BASE_URL = import.meta.env.VITE_SOCKET_BASE_URL;
 export const successStyles = {
   style: {
     maxWidth: "50rem",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,11 +1,11 @@
 // export const BASE_URL = "https://r845fh.bibuain.ng/api/v1";
 // export const SOCKET_BASE_URL = "https://r845fh.bibuain.ng";
 
-// export const BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com/api/v1";
-// export const SOCKET_BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com";
+export const BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com/api/v1";
+export const SOCKET_BASE_URL = "https://svmfu33phm.ap-southeast-1.awsapprunner.com";
 
-export const BASE_URL = "http://localhost:7001/api/v1";
-export const SOCKET_BASE_URL = "http://localhost:7001";
+// export const BASE_URL = "http://localhost:7001/api/v1";
+// export const SOCKET_BASE_URL = "http://localhost:7001";
 export const successStyles = {
   style: {
     maxWidth: "50rem",

--- a/src/lib/interface.ts
+++ b/src/lib/interface.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface ResInterface {
+  failure: any;
   costPrice(costPrice: any): unknown;
   id(id: any): void | PromiseLike<void>;
   message: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

Fix the elapsed time to be stable, and also remove decimals.
Added new logic on payer's dashboard :
- Clock-In – Select Funded Bank
	•	Payer is shown a list of Funded Banks (banks with balance > ₦0).
	•	Payer selects one bank to start with.
- Confirm Opening Balance
	•	System displays selected bank’s current balance.
	•	Payer confirms the balance.
	•	This balance appears at the top of their transaction screen throughout the shift.
- Payment Tracking
	•	As the payer sends payments:
	•	Amounts are auto-deducted from the selected bank’s balance.
	•	Live balance updates continue in real-time.

 - Request New Bank (When Bank is Exhausted)
	•	When current bank balance = ₦0:
	•	“Request New Bank” button becomes active.
	•	On click:
                     - System verifies that current bank is truly ₦0.
                     - That exhausted bank is automatically moved to “Rollover Banks.”
                     - A new popup shows all available Funded Banks.
                     - Payer selects a new bank and confirms its opening balance.
                     - This can be repeated multiple times during the shift.

- Clock-Out
	•	When payer clicks “Clock-Out”, a popup appears.
         -  System will:
		Automatically list all banks used during the shift, including exhausted banks.
         - Payer will: confirm closing balance, as they don't have the authorization to edit bank amount

- Customer care page now auto refresh, but there is still some bugs to fix as escalated page still flickers and others are working well

-  Upgrade the display funds color in payer trades to suit this request:
      Show bank status based on current balance:
           - ✅ Available (₦5M+) – Green
           - ⚠️ Amber (₦1M–₦4.99M) – Orange
           - ❌ Low (₦0–₦999,999) – Red